### PR TITLE
Fix wrong condition in Admin.php

### DIFF
--- a/src/Hook/Admin.php
+++ b/src/Hook/Admin.php
@@ -216,12 +216,13 @@ class Admin extends AbstractHook
 
     public function displayAdminOrder($params): string
     {
-        if ($this->module->name != 'tpay') {
+        $orderId = $params['id_order'];
+        $order = new Order($orderId);
+
+        if ($order->module !== 'tpay') {
             return '';
         }
 
-        $orderId = $params['id_order'];
-        $order = new Order($orderId);
         $currency = new Currency($order->id_currency);
         $surchargeService = $this->module->getService('tpay.service.surcharge');
         $transactionService = $this->module->getService('tpay.repository.transaction');


### PR DESCRIPTION
The original condition in the code was confusing and didn't make sense.

This pull request fixes the module and prevents it from hiding UI elements related to refund management.

I also recommend reconsidering the decision to hide this element in the first place. Regardless, the fix is still necessary.