### PR TITLE
fix: update blik payment response and JS handler to support retry

### DIFF
--- a/controllers/front/chargeBlik.php
+++ b/controllers/front/chargeBlik.php
@@ -146,6 +146,7 @@ class TpayChargeBlikModuleFrontController extends ModuleFrontController
 
         $blikCode = $this->validateBlikCode(Tools::getValue('blikCode'));
         $transaction = $this->createBlikZero($transactionParams, $blikCode, $customer->isGuest() ? null : $cart);
+        $transactionId = $transaction['transactionId'];
 
         $this->cancelTransaction($oldTransactionId);
         $transactionRepository = $this->module->getService('tpay.repository.transaction');
@@ -165,6 +166,7 @@ class TpayChargeBlikModuleFrontController extends ModuleFrontController
             json_encode(
                 [
                     'result' => $result['status'],
+                    'transactionId' => $transactionId,
                 ]
             )
         );

--- a/views/templates/hook/thank_you_page.tpl
+++ b/views/templates/hook/thank_you_page.tpl
@@ -122,6 +122,8 @@
             const paymentsInputs = document.getElementsByName('payment');
             const action = '{$action}';
 
+            let currentTransactionId = "{$transactionId}";
+
             if (parseInt(parseInt(localStorage.getItem('tpay_transaction_counter'))) === 3) {
                 document.querySelector('.payment-section').style.display = 'block';
                 document.querySelector('.transfer_payment').style.display = 'block';
@@ -151,7 +153,7 @@
                 let paymentData = {
                     action: 'blik0Status',
                     cartId: "{$cartId}",
-                    transactionId: "{$transactionId}"
+                    transactionId: currentTransactionId
                 };
                 const data = (new URLSearchParams(paymentData)).toString();
 
@@ -243,7 +245,7 @@
                 let paymentData = {
                     action: 'blik0Status',
                     cartId: "{$cartId}",
-                    transactionId: "{$transactionId}"
+                    transactionId: currentTransactionId
                 };
 
                 if (isBlik()) {
@@ -277,6 +279,10 @@
                 })
                     .then(response => {
                         return response.json().then(data => {
+                            if (data.transactionId) {
+                                currentTransactionId = data.transactionId;
+                            }
+
                             if (data.result === 'correct') {
                                 document.querySelector('.payment-section').style.display = 'none';
                                 document.querySelector('.payment-confirmation-container').style.display = 'block';


### PR DESCRIPTION
**Problem:**
When a second BLIK payment attempt (on the confirmation page) fails, the frontend still holds the old `transactionId` which has already been overwritten in the database and canceled in Tpay. As a result, third retry looks up the first `transactionId` in the database, doesn't find it, and creates a new entry for the same `order_id` - leaving the second transaction pending.

**Fix:**
Update the `chargeBlik::payBlikTransaction` response to return the new `transactionId` and update the JS handler to use it, so each retry always references the correct transaction.